### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ printobject
 .. image:: https://travis-ci.org/numerodix/printobject.png?branch=master
     :target: https://travis-ci.org/numerodix/printobject
 
-.. image:: https://pypip.in/license/printobject/badge.png
+.. image:: https://img.shields.io/pypi/l/printobject.svg
         :target: https://pypi.python.org/pypi/printobject/
 
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20printobject))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `printobject`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.